### PR TITLE
Stage monitoring reseau

### DIFF
--- a/Commandes déploiement des outils de monitoring
+++ b/Commandes déploiement des outils de monitoring
@@ -1,10 +1,10 @@
 # 0. si besoin des commandes de déploiement des pods (control-plane et machines 1 et 2 )
   # Se placer dans le dossier du control-plane
   cd control-plane
-
   # Builder l'image Docker (remplacer v3 par la version souhaitée)
   docker build -t control-plane:v3 . 
-  
+  #importer l'image 
+  minikube image load control-plane:v3
   # Déployer le control-plane avec Kubernetes
   minikube kubectl -- apply -f control-plane.yaml
 
@@ -34,7 +34,13 @@ helm repo update
 # Installer Prometheus et Grafana avec le chart kube-prometheus-stack
 helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace
 
-# Vérifier que les pods sont bien déployés
+# remarque : Si on veut personnaliser la stack (ajouter des règles, modifier la config), directement à l'installation de Prometheus, on peut appliquer un fichier "prometheus-values.yaml" (déja fournis par exemple) avant l’installation, puis de l’utiliser lors du helm install :
+helm install prometheus prometheus-community/kube-prometheus-stack --namespace monitoring --create-namespace -f prometheus-values.yaml
+
+#ou alors appliquer seulement la commande précédente et par la suite faire un "helm upgrade" avec la configuration qu'on veut appliquer.
+
+# Vérifier que les pods sont bien déployés (on est sensés avoir 
+# des pods pour Prometheus, Grafana, Alertmanager, Node Exporter, Kube State Metrics, etc.) 
 minikube kubectl -- get pods -n monitoring
 
 
@@ -42,20 +48,19 @@ minikube kubectl -- get pods -n monitoring
 # Prometheus
 minikube kubectl -- port-forward svc/prometheus-kube-prometheus-prometheus 9090:9090 -n monitoring
 
-# Grafana (port 3000 ou autre si déjà utilisé)
+# Grafana dans un autre terminal (port 3000 ou autre si déjà utilisé)
 minikube kubectl -- port-forward svc/grafana 3000:80 -n monitoring
 # Si le port 3000 est occupé, choisir un autre port, ex :
 minikube kubectl -- port-forward svc/grafana 3001:80 -n monitoring
 
 # Vérifier quel processus utilise un port (ex : 3000)
 sudo lsof -i :3000
-# Tuer le processus si besoin (remplacer 361475 par le bon PID)
-sudo kill -9 361475
-
   
-# 3. Récupération du mot de passe admin Grafana
-user : admin 
+# 3. Récupération du mot de passe admin Grafana puis accéder à Grafana via http://localhost:3000 (ou 3001 selon le port utilisé pour le port forward précédent)
 minikube kubectl -- get secret --namespace monitoring grafana -o jsonpath="{.data.admin-password}" | base64 --decode ; echo
+
+user : admin 
+mot de passe : récupéré via la commande précédente
 
 
 # 4. Déploiement et vérification de Node Exporter 
@@ -69,7 +74,11 @@ minikube kubectl -- get services -n monitoring
 
 
 # 5. Mise à jour de la stack (si modification de la config) 
-helm upgrade prometheus prometheus-community/kube-prometheus-stack -f prometheus-values.yaml -n monitoring
+helm upgrade prometheus prometheus-community/kube-prometheus-stack -f prometheus-values.yaml -n monitoring 
+# remarque : cette commande ajoute la configuration des alertes concernant les NODES du cluster, et non pas les pods
+
+#pour ajouter les règles de surveillance des pods : 
+kubectl apply -f pod-cpu-usage-levels.yaml
 
 
 # 6. Configuration d’Alertmanager pour l’envoi d’emails
@@ -77,7 +86,7 @@ helm upgrade prometheus prometheus-community/kube-prometheus-stack -f prometheus
 # Exporter la configuration actuelle
 minikube kubectl -- get secret alertmanager-prometheus-kube-prometheus-alertmanager -n monitoring -o jsonpath="{.data.alertmanager\.yaml}" | base64 -d > alertmanager.yaml
 
-# Modifier alertmanager.yaml (ajouter la config email), sauvegarder puis réencoder
+# Modifier alertmanager.yaml (cmodifier en copiant et collant le contenu du fichier du fichier alertmanagerPersonnalisé.yaml ), sauvegarder puis réencoder
 base64 -w0 alertmanager.yaml > alertmanager.yaml.b64
 
 # Réimporter dans Kubernetes (patch le secret)
@@ -117,6 +126,66 @@ http://localhost:3000
 cd slo-tracker
 #Puis poursuivre avec la vérification du port et le lancement du déploiement comme ci-dessus.
 
+8. # Vérifier que les pods sont bien déployés (on est sensés avoir 
+# des pods pour Prometheus, Grafana, Alertmanager, Node Exporter, Kube State Metrics, etc.)
+minikube kubectl -- get pods -n monitoring
+
+# 8. Configuration de Grafana pour la visualisation des métriques
+
+# Pour Grafana, il n'y a pas de fichier de configuration spécifique à déployer.
+# Il suffit de créer des dashboards directement sur l'interface graphique.
+
+# Étapes pour configurer Grafana :
+
+# a) Ajouter Prometheus comme source de données dans Grafana :
+# - Accéder à l'interface Grafana (via port-forward sur http://localhost:3001)
+# - Aller dans : Home > Data Sources > Add new data source
+# - Choisir "Prometheus" comme type de source de données
+# - Dans le champ URL, saisir : http://prometheus-kube-prometheus-prometheus.monitoring.svc.cluster.local:9090
+# - Laisser tous les autres paramètres par défaut
+# - Cliquer sur "Save & Test" (doit afficher "Data source is working")
+
+# Important : Ne pas utiliser http://localhost:9090 comme URL car Grafana et Prometheus tournent dans le cluster.
+# Il faut utiliser le nom DNS interne du service Kubernetes.
+
+# Pour retrouver l'URL interne d'un service Kubernetes :
+minikube kubectl -- get svc -n monitoring
+#alors on met l'URL http://<nom_du_service>.<namespace>.svc.cluster.local:<port>
+
+
+# b) Créer des dashboards sur l'interface graphique :
+# - Dans la barre latérale gauche, cliquer sur "+" (Add) > Dashboard > Add new panel
+# - Sélectionner Prometheus comme source de données
+# - Saisir les requêtes PromQL pour les métriques souhaitées
+# - Choisir le type de visualisation (Graph/Time series, Stat, Table, etc.)
+# - Donner un titre au panel et cliquer sur "Apply"
+# - Sauvegarder le dashboard avec un nom explicite
+
+# Exemples de requêtes PromQL utiles :
+
+# CPU Usage per Node :
+# 100 - (avg by(instance)(rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100)
+
+# Memory Usage per Node :
+# (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100
+
+# CPU Usage per Pod :
+# sum by(pod, namespace) (rate(container_cpu_usage_seconds_total{cpu="total"}[5m]))
+
+# Memory Usage per Pod (as % of limit) :
+# sum by(pod, namespace) (container_memory_usage_bytes) / sum by(pod, namespace) (container_spec_memory_limit_bytes > 0)
+
+# Network Traffic per Pod (Incoming) :
+# sum by(pod, namespace) (rate(container_network_receive_bytes_total[5m]))
+
+# Network Traffic per Pod (Outgoing) :
+# sum by(pod, namespace) (rate(container_network_transmit_bytes_total[5m]))
+
+
+(Optionnel) Vérification de l’état général du cluster
+#Pour avoir une vue d’ensemble de tous les pods, tous namespaces confondus :
+
+minikube kubectl -- get pods -A
 
 
 

--- a/Commandes déploiement des outils de monitoring
+++ b/Commandes déploiement des outils de monitoring
@@ -1,3 +1,24 @@
+# 0. si besoin des commandes de déploiement des pods (control-plane et machines 1 et 2 )
+  # Se placer dans le dossier du control-plane
+  cd control-plane
+
+  # Builder l'image Docker (remplacer v3 par la version souhaitée)
+  docker build -t control-plane:v3 . 
+  
+  # Déployer le control-plane avec Kubernetes
+  minikube kubectl -- apply -f control-plane.yaml
+
+  #Idem pour les workers (machine-1 et machine-2)
+  cd worker
+  docker build -t worker:v3 .
+  minikube image load worker:v3
+  minikube kubectl -- apply -f machine-1.yaml
+  minikube kubectl -- apply -f machine-2.yaml
+
+  # Pour vérifier que tout fonctionne :
+  minikube kubectl -- get pods
+  minikube kubectl -- get services
+
 # 1. Installation de Helm, Prometheus et Grafana
 
 # Installer Helm (si ce n’est pas déjà fait)
@@ -74,6 +95,7 @@ minikube kubectl -- port-forward -n monitoring alertmanager-prometheus-kube-prom
 sudo apt-get update
 sudo apt-get install docker-compose
 
+# a- Via GitHub
 # Cloner le projet
 git clone https://github.com/roshan8/slo-tracker.git
 cd slo-tracker
@@ -84,4 +106,18 @@ sudo netstat -tlnp | grep :3306
 # Modifier le port dans docker-compose.yml si besoin (ex : 3307)
 # Puis lancer le déploiement
 docker-compose up -d
+
+Vérification  (accéder à l'interface SLO Tracker) : 
+http://localhost:3000 
+
+# b- Via le dossier déjà importé dans le repository
+# s'il est bien importé, il suffit de sauter l’étape du git clone.
+# se placer simplement dans le répertoire de slo tracker 
+
+cd slo-tracker
+#Puis poursuivre avec la vérification du port et le lancement du déploiement comme ci-dessus.
+
+
+
+
 

--- a/Prometheus et Alertmanager/alertmanagerPersonnalisé.yaml
+++ b/Prometheus et Alertmanager/alertmanagerPersonnalisé.yaml
@@ -2,7 +2,7 @@
 # J’ai renommé ce fichier en "Personnalisé" pour éviter d’écraser la config d’origine extraite après le déploiement d’Alertmanager (qui s’appelle aussi alertmanager.yaml par défaut).
 # Pour rappel, on extrait la config actuelle avec :
 # minikube kubectl -- get secret alertmanager-prometheus-kube-prometheus-alertmanager -n monitoring -o jsonpath="{.data.alertmanager\.yaml}" | base64 -d > alertmanager.yaml
-# Ensuite, il suffit de copier le contenu dans le vrai alertmanager.yaml, puis de réencoder avec :
+# Ensuite, il suffit de copier le contenu de ce fichier dans le vrai alertmanager.yaml, puis de réencoder avec :
 # base64 -w0 alertmanager.yaml > alertmanager.yaml.b64
 # (Toutes les commandes détaillées sont dans le fichier joint au projet)
 

--- a/Prometheus et Alertmanager/alertmanagerPersonnalisé.yaml
+++ b/Prometheus et Alertmanager/alertmanagerPersonnalisé.yaml
@@ -7,22 +7,22 @@
 # (Toutes les commandes détaillées sont dans le fichier joint au projet)
 
 global:
-  resolve_timeout: 5m
-  smtp_smarthost: 'smtp.gmail.com:587'
-  smtp_from: 'monitoringk8s@gmail.com'
-  smtp_auth_username: 'monitoringk8s@gmail.com'
-  smtp_auth_password: 'batk bazm nfmg lutk'
-  smtp_require_tls: true
+  resolve_timeout: 5m  # Délai avant de considérer une alerte comme résolue
+  smtp_smarthost: 'smtp.gmail.com:587'  # Serveur SMTP utilisé pour l'envoi des mails
+  smtp_from: 'monitoringk8s@gmail.com'  # Adresse d'expédition des alertes email
+  smtp_auth_username: 'monitoringk8s@gmail.com'  # Identifiant SMTP (adresse email)
+  smtp_auth_password: 'batk bazm nfmg lutk'  # Mot de passe d’application Gmail (voir rapport pour la procédure de création)
+  smtp_require_tls: true  # Connexion sécurisée TLS obligatoire
 
 route:
-  group_by: ['alertname']
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 1h
-  receiver: 'null'  # Par défaut, rien n'est envoyé
+  group_by: ['alertname']  # Grouper les alertes par nom
+  group_wait: 30s          # Attendre 30s avant d’envoyer un groupe d’alertes
+  group_interval: 5m       # Attendre 5min entre deux groupes d’alertes similaires
+  repeat_interval: 1h      # Répéter l’alerte toutes les heures si elle persiste
+  receiver: 'null'         # Par défaut, aucune notification n’est envoyée
 
   routes:
-    # Ignorer les alertes Watchdog
+    # Ignore les alertes Watchdog (pour éviter le spam)
     - matchers:
         - alertname="Watchdog"
       receiver: "null"
@@ -61,11 +61,11 @@ route:
       receiver: "slo-tracker-webhook"
 
 receivers:
-  - name: "null"
+  - name: "null"  # Receiver vide, utilisé pour ignorer certaines alertes
 
   - name: "mail-and-slo-tracker"
     email_configs:
-      - to: 'monitoringk8s@gmail.com'
+      - to: 'monitoringk8s@gmail.com'  # Adresse de réception des alertes (modifiable)
         send_resolved: false
         html: |
           <h3>🚨 Alerte Kubernetes - {{ .CommonLabels.alertname }}</h3>
@@ -79,20 +79,21 @@ receivers:
           </ul>
           <p><i>Notification limitée selon la criticité de l'alerte.</i></p>
     webhook_configs:
-      - url: 'http://192.168.46.133:8080/api/v1/incident/1/webhook/prometheus'
-        send_resolved: true
+      - url: 'http://192.168.46.133:8080/api/v1/incident/1/webhook/prometheus'  # Webhook vers une app sur une autre machine du réseau
 
   - name: 'flask-webhook'
     webhook_configs:
-      - url: 'http://192.168.46.249:5000/alert'
-        send_resolved: true
+      - url: 'http://192.168.46.249:5000/alert'  # Webhook vers une app Flask sur une autre machine du réseau
+        # Si l'application Flask est déployée sur la même machine que l'Alertmanager, remplacer l'IP par localhost :
+        # url: 'http://localhost:5000/alert'
 
   - name: 'slo-tracker-webhook'
     webhook_configs:
-      - url: 'http://192.168.46.133:8080/api/v1/incident/1/webhook/prometheus'
-        send_resolved: true
+      - url: 'http://192.168.46.133:8080/api/v1/incident/1/webhook/prometheus'  # Webhook récupéré dans SLO tracker (section "Intégrations" > "Ajouter Prometheus" > copier le lien fourni)
+        # Même si le SLO tracker est sur la même machine, il faut utiliser le lien fourni par l'interface SLO tracker (ne pas remplacer par localhost sauf indication contraire dans la doc SLO tracker)
 
 inhibit_rules:
+  # Inhibe (masque) les alertes warning si une alerte critical existe pour le même pod/namespace
   - source_matchers:
       - severity="critical"
     target_matchers:
@@ -102,6 +103,7 @@ inhibit_rules:
       - pod
       - namespace
 
+  # Inhibe les alertes PodCpuNormal si une alerte critique CPU existe déjà pour le même pod/namespace
   - source_matchers:
       - alertname=~"PodHighCpuUsage|PodCpuFailure"
     target_matchers:
@@ -111,4 +113,4 @@ inhibit_rules:
       - namespace
 
 templates:
-  - /etc/alertmanager/config/*.tmpl
+  - /etc/alertmanager/config/*.tmpl  # Fichiers de template pour personnaliser les emails/messages

--- a/Prometheus et Alertmanager/pod-cpu-usage-levels.yaml
+++ b/Prometheus et Alertmanager/pod-cpu-usage-levels.yaml
@@ -1,23 +1,28 @@
+# ===========================================================
+# Fichier à déployer pour la configuration des alertes Prometheus sur les pods
+# Ce fichier définit les règles d'alerte CPU et mémoire pour chaque pod Kubernetes
+# ===========================================================
+
 apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
+kind: PrometheusRule  # Définit des règles d'alertes pour Prometheus
 metadata:
   name: pod-cpu-usage-levels
-  namespace: monitoring
+  namespace: monitoring  # Namespace où déployer les règles
   labels:
-    release: prometheus
+    release: prometheus  # Label nécessaire pour que Prometheus découvre automatiquement ces règles
 spec:
   groups:
-  - name: pod.rules
+  - name: pod.rules  # Nom du groupe de règles
     rules:
-    # Alerte d'information : CPU normal (limitée à 1 notification/heure)
+    # Alerte d'information : CPU normal (< 50%)
     - alert: PodCpuNormal
       expr: |
         sum by(pod, namespace) (
-          rate(container_cpu_usage_seconds_total{cpu="total"}[5m])
-        ) < 0.5
-      for: 5m
+          rate(container_cpu_usage_seconds_total{cpu="total"}[5m])  # Calcule le taux d'utilisation CPU sur 5 minutes
+        ) < 0.5  # Déclenche si CPU < 50%
+      for: 5m  # Attendre 5 minutes avant de déclencher l'alerte
       labels:
-        severity: info
+        severity: info  # Niveau d'alerte : informatif
       annotations:
         summary: "CPU usage is normal on pod {{ $labels.pod }} (namespace {{ $labels.namespace }})"
         description: "CPU usage is below 50% for more than 5 minutes on pod {{ $labels.pod }}."
@@ -27,14 +32,14 @@ spec:
       expr: |
         sum by(pod, namespace) (
           rate(container_cpu_usage_seconds_total{cpu="total"}[5m])
-        ) > 0.8
+        ) > 0.8  # CPU > 80%
         and
         sum by(pod, namespace) (
           rate(container_cpu_usage_seconds_total{cpu="total"}[5m])
-        ) < 0.99
-      for: 5m
+        ) < 0.99  # ET CPU < 99% (pour éviter le chevauchement avec l'alerte critique)
+      for: 5m  # Attendre 5 minutes avant de déclencher l'alerte
       labels:
-        severity: warning
+        severity: warning  # Niveau d'alerte : avertissement
       annotations:
         summary: "High CPU usage on pod {{ $labels.pod }} (namespace {{ $labels.namespace }})"
         description: "CPU usage is between 80% and 99% for more than 5 minutes on pod {{ $labels.pod }}."
@@ -44,25 +49,25 @@ spec:
       expr: |
         sum by(pod, namespace) (
           rate(container_cpu_usage_seconds_total{cpu="total"}[5m])
-        ) >= 0.99
-      for: 2m
+        ) >= 0.99  # CPU ≥ 99%
+      for: 2m  # Attendre seulement 2 minutes (plus urgent que les autres alertes)
       labels:
-        severity: critical
+        severity: critical  # Niveau d'alerte : critique
       annotations:
         summary: "CRITICAL CPU usage on pod {{ $labels.pod }} (namespace {{ $labels.namespace }})"
         description: "CPU usage is at or above 99% for more than 2 minutes on pod {{ $labels.pod }}! Immediate action required."
 
-    # Alerte mémoire élevée
+    # Alerte mémoire élevée (> 80% de la limite)
     - alert: PodHighMemoryUsage
       expr: |
         sum by(pod, namespace) (
-          container_memory_usage_bytes
+          container_memory_usage_bytes  # Mémoire utilisée en bytes
         ) / sum by(pod, namespace) (
-          container_spec_memory_limit_bytes > 0
-        ) > 0.8
-      for: 5m
+          container_spec_memory_limit_bytes > 0  # Limite de mémoire configurée (si définie)
+        ) > 0.8  # Déclenche si utilisation > 80% de la limite
+      for: 5m  # Attendre 5 minutes avant de déclencher l'alerte
       labels:
-        severity: warning
+        severity: warning  # Niveau d'alerte : avertissement
       annotations:
         summary: "High memory usage on pod {{ $labels.pod }} (namespace {{ $labels.namespace }})"
         description: "Memory usage is above 80% of limit for more than 5 minutes on pod {{ $labels.pod }}."

--- a/Prometheus et Alertmanager/prometheus-values.yaml
+++ b/Prometheus et Alertmanager/prometheus-values.yaml
@@ -4,7 +4,7 @@
 # ⚠️ Ce fichier s'applique via Helm (ex : helm upgrade ...) et NON via kubectl apply
 #     car il fait partie de la configuration chart/kube-prometheus-stack.
 # Différence avec le précédent :
-#   - Le précédent (PrometheusRule) ne concerne que les PODS et s'applique avec kubectl apply.
+#   - Le précédent pod-cpu-usage-levels.yaml(PrometheusRule) ne concerne que les PODS et s'applique avec kubectl apply.
 #   - Celui-ci configure à la fois le scraping des métriques des nœuds et les règles d'alerte sur les NODES,
 #     et doit être injecté dans la release Helm de Prometheus (souvent via values.yaml ou un fichier custom).
 # ===========================================================

--- a/Prometheus et Alertmanager/prometheus-values.yaml
+++ b/Prometheus et Alertmanager/prometheus-values.yaml
@@ -1,4 +1,15 @@
-prometheus: #ce fichier est a appliquer avec helm upgrade et non avec kubectl apply, il configure les node rules et non pas les pod rules
+# ===========================================================
+# Fichier de configuration Prometheus pour la supervision des NODES Kubernetes
+# À utiliser pour définir les règles d'alerte sur les ressources des nœuds (CPU, mémoire, disque, etc.)
+# ⚠️ Ce fichier s'applique via Helm (ex : helm upgrade ...) et NON via kubectl apply
+#     car il fait partie de la configuration chart/kube-prometheus-stack.
+# Différence avec le précédent :
+#   - Le précédent (PrometheusRule) ne concerne que les PODS et s'applique avec kubectl apply.
+#   - Celui-ci configure à la fois le scraping des métriques des nœuds et les règles d'alerte sur les NODES,
+#     et doit être injecté dans la release Helm de Prometheus (souvent via values.yaml ou un fichier custom).
+# ===========================================================
+
+prometheus: # Ce bloc configure Prometheus via Helm (chart kube-prometheus-stack)
   prometheusSpec:
     additionalScrapeConfigs:
       - job_name: 'prometheus'
@@ -25,6 +36,7 @@ additionalPrometheusRules:
     groups:
       - name: pod-cpu.rules
         rules:
+          # Règles d'alerte sur les pods (CPU)
           - alert: CpuNormal
             expr: |
               sum by(pod, namespace) (
@@ -73,6 +85,7 @@ additionalPrometheusRules:
               namespace: "{{ $labels.namespace }}"
               cpu: "{{ printf \"%.2f\" $value }}"
 
+          # Règle d'alerte sur l'utilisation du disque des NODES
           - alert: HighDiskUsage
             expr: 100 * (node_filesystem_size_bytes{fstype!~"tmpfs|overlay"} - node_filesystem_free_bytes{fstype!~"tmpfs|overlay"}) / node_filesystem_size_bytes{fstype!~"tmpfs|overlay"} > 80
             for: 5m
@@ -82,6 +95,7 @@ additionalPrometheusRules:
               summary: "Disk usage is high on instance {{ $labels.instance }} (mountpoint {{ $labels.mountpoint }})"
               description: "Disk usage is above 80% for more than 5 minutes on {{ $labels.mountpoint }}."
 
+          # Règle d'alerte sur la mémoire des NODES
           - alert: HighMemoryUsage
             expr: 100 * (1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) > 80
             for: 5m
@@ -89,4 +103,4 @@ additionalPrometheusRules:
               severity: critical
             annotations:
               summary: "Memory usage is high on instance {{ $labels.instance }}"
-              description: "Memory usage is above 80% for more than 5 minutes."
+              description: "Memory usage is above 80% for more than 5 minutes on the node."

--- a/control/Dockerfile
+++ b/control/Dockerfile
@@ -1,12 +1,12 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && \
-    apt-get install -y netcat bash && \
+    apt-get install -y netcat bash && \ #netcat est utilisé pour envoyer des données aux workers.
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 
-COPY run-control.sh .
+COPY run-control.sh . #le script principal qui envoie des nombres aléatoires aux workers.
 
 RUN chmod +x run-control.sh
 

--- a/control/run-control.sh
+++ b/control/run-control.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+#Boucle infinie qui génère un nombre aléatoire et l’envoie aux deux workers via TCP.
 
 echo "=== Control-plane démarre ==="
 

--- a/control/start.sh
+++ b/control/start.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-# Lancer le serveur TCP en C en arrière-plan
-./tcp_server &
-
-# Lancer Flask
-python3 app.py

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:16.04
 
 # Installer les outils de compilation et Python
 RUN apt-get update && apt-get install -y \

--- a/worker/app.py
+++ b/worker/app.py
@@ -15,4 +15,7 @@ def index():
 
 if __name__ == '__main__':
     print("=== Flask demarre ===")
-    app.run(host='0.0.0.0', port=5000, debug=True, use_reloader=False)
+    app.run(host='0.0.0.0', port=5001, debug=True, use_reloader=False)
+
+ #éviter d'utiliser le port 5000 qui est souvent utilisé pour les applications Flask car il sera utilisé po pour la deuxieme application Flask qui reçoit les alertes Prometheus 
+#et lance les scripts nécéessaires selon l'alerte reçue

--- a/worker/machine-1.yaml
+++ b/worker/machine-1.yaml
@@ -21,7 +21,7 @@ spec:
         image: worker-node:v3    # Image Docker à utiliser pour ce worker
         ports:
         - containerPort: 8080    # Port pour le serveur TCP (réception des nombres)
-        - containerPort: 5000    # Port pour l’interface web Flask
+        - containerPort: 5001    # Port pour l’interface web Flask
 
 ---
 # Service interne pour exposer le port TCP du worker (utilisé par le control-plane)
@@ -47,6 +47,6 @@ spec:
   selector:
     app: machine-1
   ports:
-  - port: 5000                          # Port du service (HTTP Flask)
-    targetPort: 5000                    # Port du container Flask
+  - port: 5001                          # Port du service (HTTP Flask)
+    targetPort: 5001                    # Port du container Flask
     nodePort: 30001                     # Port du nœud Minikube (accès via http://<IP_minikube>:30001 )

--- a/worker/machine-1.yaml
+++ b/worker/machine-1.yaml
@@ -1,47 +1,52 @@
+# Déploiement du worker machine-1
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: machine-1
+  name: machine-1                # Nom du déploiement
 spec:
-  replicas: 1
+  replicas: 1                    # Un seul pod (instance) pour ce worker
   selector:
     matchLabels:
-      app: machine-1
+      app: machine-1             # Sélecteur pour faire correspondre le pod au déploiement
   template:
     metadata:
       labels:
-        app: machine-1
-        fogsla: ok
+        app: machine-1           # Label pour identifier ce pod
+        fogsla: ok              # Label additionnel (sert pour la supervision : permet de cibler ce pod pour la gestion dynamique des ressources par la suite)
     spec:
       nodeSelector:
-        kubernetes.io/hostname: minikube-m02
+        kubernetes.io/hostname: minikube-m02  # Force le pod à s’exécuter sur le nœud minikube-m02
       containers:
       - name: worker
-        image: worker-node:v3
+        image: worker-node:v3    # Image Docker à utiliser pour ce worker
         ports:
-        - containerPort: 8080
-        - containerPort: 5000
+        - containerPort: 8080    # Port pour le serveur TCP (réception des nombres)
+        - containerPort: 5000    # Port pour l’interface web Flask
+
 ---
+# Service interne pour exposer le port TCP du worker (utilisé par le control-plane)
 apiVersion: v1
 kind: Service
 metadata:
-  name: sla-project-machine-1-service
+  name: sla-project-machine-1-service   # Nom du service (utilisé par le control-plane pour envoyer les nombres)
 spec:
   selector:
-    app: machine-1
+    app: machine-1                      # Associe ce service au pod ayant ce label
   ports:
-  - port: 8080
-    targetPort: 8080
+  - port: 8080                          # Port exposé par le service
+    targetPort: 8080                    # Port du container à atteindre
+
 ---
+# Service NodePort pour accéder à l’interface web Flask depuis l’extérieur
 apiVersion: v1
 kind: Service
 metadata:
-  name: machine-1-nodeport
+  name: machine-1-nodeport              # Nom du service NodePort
 spec:
-  type: NodePort
+  type: NodePort                        # Permet d’accéder au service via un port du nœud Minikube
   selector:
     app: machine-1
   ports:
-  - port: 5000
-    targetPort: 5000
-    nodePort: 30001
+  - port: 5000                          # Port du service (HTTP Flask)
+    targetPort: 5000                    # Port du container Flask
+    nodePort: 30001                     # Port du nœud Minikube (accès via http://<IP_minikube>:30001 )

--- a/worker/machine-2.yaml
+++ b/worker/machine-2.yaml
@@ -20,7 +20,7 @@ spec:
         image: worker-node:v3
         ports:
         - containerPort: 8080
-        - containerPort: 5000
+        - containerPort: 5001
 ---
 apiVersion: v1
 kind: Service
@@ -42,6 +42,6 @@ spec:
   selector:
     app: machine-2
   ports:
-  - port: 5000
-    targetPort: 5000
+  - port: 5001
+    targetPort: 5001
     nodePort: 30002

--- a/worker/start.sh
+++ b/worker/start.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
-
+#Lance le serveur TCP en arrière-plan, puis Flask.
 export PYTHONIOENCODING=utf-8
 
 # Lancer le serveur TCP en arrière-plan
 /app/tcp_server &
 
-
 # Lancer Flask
 python3 /app/app.py
+
+


### PR DESCRIPTION
Mise à jour complète de la documentation de déploiement pour déployer l'infrastructure de monitoring (Prometheus, Grafana, Alertmanager, SLO Tracker) sur Kubernetes/Minikube, ajout de quelques commentaires expliquant les configurations pour mieux comprendre les fichiers, configurations et instructions détaillées.